### PR TITLE
Business logic flaw fix: Email validation added

### DIFF
--- a/app/server/routes.js
+++ b/app/server/routes.js
@@ -79,6 +79,9 @@ module.exports = function(app) {
 				country	: req.body['country']
 			}, function(e, o){
 				if (e){
+					if (e === 'email-taken') {
+            return res.status(400).send('email-taken');
+          }
 					res.status(400).send('error-updating-account');
 				}	else{
 					req.session.user = o.value;


### PR DESCRIPTION
### 📊 Metadata *

node-login is a template for quickly building login systems on top of Node.js & MongoDB. The business logic which updates account details fails to verify if the provied email is associated with another account.

#### Bounty URL: https://www.huntr.dev/bounties/2-other-node-login

### ⚙️ Description *

Whenever account details are updated, the email is validated against existing users, to avoid identical email accounts.

### 💻 Technical Description *

When an update request is initialized, `email` attribute in request body is used to run a query to determine, whether an account exists with the same email address. If there exists, and it's not the same user, then request is rejected and appropriate error message is shown in the browser.

### 🐛 Proof of Concept (PoC) *

Navigate to /signup and Create two accounts with data like below
Account 1 - username: victim, email: victim@test.com
Account 2 - username: hacker, email: hacker@test.com
Account creation functionality does not allows to create user with existing email. poc1
Login to the hacker account
In the account update section, change the email field with victim email and submit the form. poc2
Now both accounts are associated with victim's email.
Check MongoDB backend for confirmation poc2

### 🔥 Proof of Fix (PoF) *

![image](https://user-images.githubusercontent.com/64132745/100366447-d5df3e00-3026-11eb-99b9-e62a1b53d4f6.png)

![email-validation-update-success](https://user-images.githubusercontent.com/64132745/100366815-543be000-3027-11eb-8bc3-65b9f67d6355.png)

![email-validation-update-success](https://user-images.githubusercontent.com/64132745/100366996-96652180-3027-11eb-8e9e-56caed28737d.png)

![duplicate-email-error](https://user-images.githubusercontent.com/64132745/100367108-c1e80c00-3027-11eb-80f8-6e0963dd344b.png)


### 👍 User Acceptance Testing (UAT)

After fix, functionality is unaffected.
